### PR TITLE
Multiple listeners for events with new task queue for each listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-multibindings</artifactId>
+      <version>3.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.2.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
 			version pointed to by ${gae.home} property (Typically, one used by
 			your Eclipse plug-in)
 		-->
-		<gae.version>1.9.15</gae.version>
+		<gae.version>1.9.18</gae.version>
 	</properties>
 
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
@@ -64,8 +64,13 @@ public class BackgroundTasksModule extends AbstractModule {
   }
 
   @Provides
-  public AsyncEventListenersFactory getAsyncEventListenerFactory(final Injector injector) {
+  public AsyncEventListenersFactory getAsyncEventListenersFactory(final Injector injector) {
     return new AsyncEventListenersFactory() {
+      @Override
+      public AsyncEventListener createListener(Class<? extends AsyncEventListener> eventListenerClass) {
+        return (AsyncEventListener) injector.getInstance(eventListenerClass);
+      }
+
       @Override
       public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
@@ -67,8 +67,14 @@ public class BackgroundTasksModule extends AbstractModule {
   public AsyncEventListenersFactory getAsyncEventListenersFactory(final Injector injector) {
     return new AsyncEventListenersFactory() {
       @Override
-      public AsyncEventListener createListener(Class<? extends AsyncEventListener> eventListenerClass) {
-        return (AsyncEventListener) injector.getInstance(eventListenerClass);
+      public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
+        List<AsyncEventListener> listeners = create(eventClass);
+        for (AsyncEventListener listener : listeners){
+          if(eventListenerClassName.equals(listener.getClass().getSimpleName())){
+            return injector.getInstance(listener.getClass());
+          }
+        }
+        return null;
       }
 
       @Override

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
@@ -2,13 +2,7 @@ package com.clouway.asynctaskscheduler.gae;
 
 import com.clouway.asynctaskscheduler.spi.*;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Provider;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
+import com.google.inject.*;
 import com.google.inject.servlet.ServletModule;
 
 import java.util.ArrayList;
@@ -28,36 +22,6 @@ public class BackgroundTasksModule extends AbstractModule {
       bind(TaskQueueAsyncTaskExecutorServlet.class).in(Singleton.class);
     }
   };
-
-  /**
-   * Configures which listeners to be executed after handling of a given event
-   * Should be override
-   * and implement like this :
-   * EventListenerBindingsBuilder.binder().bind(AsyncEvent.class,Lists.newArrayList(AsyncEventListenr.class,...))
-   *
-   * @return
-   */
-  public EventListenerBindingsBuilder bindEventAdditionalEventListeners() {
-    return EventListenerBindingsBuilder.binder();
-  }
-
-  public static class EventListenerBindingsBuilder {
-    Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>> map = Maps.newHashMap();
-
-    public EventListenerBindingsBuilder bind(Class<? extends AsyncEvent> eventClass, Class<? extends AsyncEventListener>... listenerClasses) {
-      map.put(eventClass, Lists.newArrayList(listenerClasses));
-      return this;
-    }
-
-
-    public static EventListenerBindingsBuilder binder() {
-      return new EventListenerBindingsBuilder();
-    }
-
-    private List<Class<? extends AsyncEventListener>> get(Class<? extends AsyncEvent> eventClass) {
-      return map.get(eventClass);
-    }
-  }
 
   @Override
   protected void configure() {
@@ -105,9 +69,13 @@ public class BackgroundTasksModule extends AbstractModule {
       @Override
       public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
 
+        TypeLiteral<Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>>> mapOfEventListeners = new TypeLiteral<Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>>>() {};
+        Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>> map;
+        map = injector.getInstance(Key.get(mapOfEventListeners));
+
         ArrayList<AsyncEventListener> listeners = Lists.newArrayList();
 
-        List<Class<? extends AsyncEventListener>> listenerClassList = bindEventAdditionalEventListeners().get(eventClass);
+        List<Class<? extends AsyncEventListener>> listenerClassList = map.get(eventClass);
         if (listenerClassList != null) {
           for (Class<? extends AsyncEventListener> listenerClass : listenerClassList) {
             AsyncEventListener listener = injector.getInstance(listenerClass);

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
@@ -68,25 +68,29 @@ public class BackgroundTasksModule extends AbstractModule {
     return new AsyncEventListenersFactory() {
       @Override
       public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
-        List<AsyncEventListener> listeners = create(eventClass);
-        for (AsyncEventListener listener : listeners){
-          if(eventListenerClassName.equals(listener.getClass().getSimpleName())){
-            return injector.getInstance(listener.getClass());
+        List<Class<? extends AsyncEventListener>> listeners = getListenerClasses(eventClass);
+        for (Class<? extends AsyncEventListener> listener : listeners){
+          if(eventListenerClassName.equals(listener.getSimpleName())){
+            return injector.getInstance(listener);
           }
         }
         return null;
       }
 
       @Override
-      public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
-
+      public List<Class<? extends AsyncEventListener>> getListenerClasses(Class<? extends AsyncEvent> eventClass) {
         TypeLiteral<Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>>> mapOfEventListeners = new TypeLiteral<Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>>>() {};
         Map<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>> map;
         map = injector.getInstance(Key.get(mapOfEventListeners));
 
+        return  map.get(eventClass);
+      }
+
+      @Override
+      public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
         ArrayList<AsyncEventListener> listeners = Lists.newArrayList();
 
-        List<Class<? extends AsyncEventListener>> listenerClassList = map.get(eventClass);
+        List<Class<? extends AsyncEventListener>> listenerClassList = getListenerClasses(eventClass);
         if (listenerClassList != null) {
           for (Class<? extends AsyncEventListener> listenerClass : listenerClassList) {
             AsyncEventListener listener = injector.getInstance(listenerClass);

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcher.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcher.java
@@ -162,7 +162,7 @@ public class RoutingEventDispatcher {
       if (txn != null) {
         txn.rollback();
       }
-      throw new RuntimeException();
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcher.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcher.java
@@ -140,7 +140,7 @@ public class RoutingEventDispatcher {
     try {
       txn = ds.beginTransaction();
 
-      List<? extends AsyncEventListener> listeners  = listenersFactory.create(event.getClass());
+      List<Class<? extends AsyncEventListener>> listeners  = listenersFactory.getListenerClasses(event.getClass());
 
       if (listeners.isEmpty()) {
         AsyncEventHandler handler = handlerFactory.create(evenHandlerClass);
@@ -148,10 +148,10 @@ public class RoutingEventDispatcher {
       } else {
         AsyncTaskScheduler asyncTaskScheduler = taskScheduler.get();
 
-        asyncTaskScheduler.add(AsyncTaskOptions.event(event).eventHandler(evenHandlerClass.getSimpleName()));
+        asyncTaskScheduler.add(AsyncTaskOptions.eventWithHandler(event, evenHandlerClass));
 
-        for (AsyncEventListener listener : listeners) {
-          asyncTaskScheduler.add(AsyncTaskOptions.event(event).eventListener(listener.getClass().getSimpleName()));
+        for (Class<? extends AsyncEventListener> listener : listeners) {
+          asyncTaskScheduler.add(AsyncTaskOptions.eventWithListener(event, listener));
         }
 
         asyncTaskScheduler.now();
@@ -180,7 +180,7 @@ public class RoutingEventDispatcher {
   }
 
   /**
-   * Validates if provided parameters are null or emty
+   * Validates if provided parameters are null or empty
    * @param params
    * @return
    */

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingTaskDispatcher.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/RoutingTaskDispatcher.java
@@ -7,12 +7,14 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
 public class RoutingTaskDispatcher {
 
+  private static final Logger log = Logger.getLogger(RoutingTaskDispatcher.class.getName());
   private final Injector injector;
 
   @Inject
@@ -39,6 +41,7 @@ public class RoutingTaskDispatcher {
 
       AsyncTask task = (AsyncTask) object;
 
+      log.info("Executing Async Task: " + task.getClass());
       task.execute(new AsyncTaskParams(params));
 
     } else {

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
@@ -47,8 +47,15 @@ public class TaskQueueAsyncTaskExecutorServlet extends HttpServlet {
       String eventClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.EVENT);
       String eventAsJson = getParameter(request, TaskQueueAsyncTaskScheduler.EVENT_AS_JSON);
 
-      //if event is passed then it should be dispatched to it's handler
-      if (!Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+      //listener details
+      String listenerId = getParameter(request, TaskQueueAsyncTaskScheduler.LISTENER_ID);
+
+      //if event and a listenerID is passed the listener should be executed. This happens so every listener can be executed in different task queue
+      if (!Strings.isNullOrEmpty(listenerId) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+
+        eventDispatcher.dispatchEventListener(eventClassAsString, eventAsJson, new Integer(listenerId));
+        //if event is passed then it should be dispatched to it's handler
+      } else if (!Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
 
         eventDispatcher.dispatchAsyncEvent(eventClassAsString, eventAsJson);
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
@@ -48,12 +48,16 @@ public class TaskQueueAsyncTaskExecutorServlet extends HttpServlet {
       String eventAsJson = getParameter(request, TaskQueueAsyncTaskScheduler.EVENT_AS_JSON);
 
       //listener details
-      String listenerId = getParameter(request, TaskQueueAsyncTaskScheduler.LISTENER_ID);
+      String listenerClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.LISTENER);
+       //handler details
+      String handlerClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.HANDLER);
 
-      //if event and a listenerID is passed the listener should be executed. This happens so every listener can be executed in different task queue
-      if (!Strings.isNullOrEmpty(listenerId) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+      if (!Strings.isNullOrEmpty(handlerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
 
-        eventDispatcher.dispatchEventListener(eventClassAsString, eventAsJson, new Integer(listenerId));
+        eventDispatcher.dispatchEventHandler(eventClassAsString, eventAsJson, handlerClassAsString);
+      } else if (!Strings.isNullOrEmpty(listenerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+
+        eventDispatcher.dispatchEventListener(eventClassAsString, eventAsJson, listenerClassAsString);
         //if event is passed then it should be dispatched to it's handler
       } else if (!Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServlet.java
@@ -46,37 +46,48 @@ public class TaskQueueAsyncTaskExecutorServlet extends HttpServlet {
       //event details
       String eventClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.EVENT);
       String eventAsJson = getParameter(request, TaskQueueAsyncTaskScheduler.EVENT_AS_JSON);
-
       //listener details
       String listenerClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.LISTENER);
        //handler details
       String handlerClassAsString = getParameter(request, TaskQueueAsyncTaskScheduler.HANDLER);
 
-      if (!Strings.isNullOrEmpty(handlerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+      dispatchAsyncEvent(eventClassAsString, eventAsJson, listenerClassAsString, handlerClassAsString);
+      dispatchEventHandler(handlerClassAsString, eventClassAsString, eventAsJson);
+      dispatchEventListener(listenerClassAsString, eventClassAsString, eventAsJson);
+      dispatchAsyncTask(asyncTaskClass ,request);
 
-        eventDispatcher.dispatchEventHandler(eventClassAsString, eventAsJson, handlerClassAsString);
-      } else if (!Strings.isNullOrEmpty(listenerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
-
-        eventDispatcher.dispatchEventListener(eventClassAsString, eventAsJson, listenerClassAsString);
-        //if event is passed then it should be dispatched to it's handler
-      } else if (!Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
-
-        eventDispatcher.dispatchAsyncEvent(eventClassAsString, eventAsJson);
-
-        // if asyncTask is provided it should be executed
-      } else if (!Strings.isNullOrEmpty(asyncTaskClass)) {
-
-        Map<String, String[]> params = Maps.newHashMap(request.getParameterMap());
-
-        //todo do not pass map here;
-        taskDispatcher.dispatchAsyncTask(params, asyncTaskClass);
-
-      }
 
     } catch (ClassNotFoundException e) {
       e.printStackTrace();
     }
 
+  }
+
+  private void dispatchAsyncTask(String asyncTaskClass, HttpServletRequest request) throws ClassNotFoundException {
+    if (!Strings.isNullOrEmpty(asyncTaskClass)) {
+      Map<String, String[]> params = Maps.newHashMap(request.getParameterMap());
+
+      //todo do not pass map here;
+      taskDispatcher.dispatchAsyncTask(params, asyncTaskClass);
+    }
+  }
+
+  private void dispatchAsyncEvent(String eventClassAsString, String eventAsJson, String listenerClassAsString, String handlerClassAsString) throws ClassNotFoundException {
+    if (!Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson) && Strings.isNullOrEmpty(handlerClassAsString) && Strings.isNullOrEmpty(listenerClassAsString)) {
+      eventDispatcher.dispatchAsyncEvent(eventClassAsString, eventAsJson);
+    }
+  }
+
+  private void dispatchEventListener(String listenerClassAsString, String eventClassAsString, String eventAsJson) throws ClassNotFoundException {
+    if (!Strings.isNullOrEmpty(listenerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+      eventDispatcher.dispatchEventListener(eventClassAsString, eventAsJson, listenerClassAsString);
+    }
+  }
+
+  private void dispatchEventHandler(String handlerClassAsString, String eventClassAsString, String eventAsJson) throws ClassNotFoundException {
+    if (!Strings.isNullOrEmpty(handlerClassAsString) && !Strings.isNullOrEmpty(eventClassAsString) && !Strings.isNullOrEmpty(eventAsJson)) {
+      eventDispatcher.dispatchEventHandler(eventClassAsString, eventAsJson, handlerClassAsString);
+    }
   }
 
   private String getParameter(HttpServletRequest request, String pramName) throws UnsupportedEncodingException {

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
@@ -55,7 +55,8 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
   public static final String TASK_QUEUE = "taskQueue";
   public static final String EVENT = "event";
   public static final String EVENT_AS_JSON = "eventJson";
-  public static final String LISTENER_ID = "listenerId";
+  public static final String LISTENER = "listener";
+  public static final String HANDLER = "handler";
 
   private List<AsyncTaskOptions> taskOptions;
 
@@ -147,8 +148,12 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
       throw new RuntimeException(e);
     }
 
-    if (taskOptions.getEventListenerId() != null){
-      task.param(LISTENER_ID, taskOptions.getEventListenerId().toString());
+    if (taskOptions.getEventListener() != null){
+      task.param(LISTENER, taskOptions.getEventListener().toString());
+    }
+
+    if (taskOptions.getEventHandler() != null){
+      task.param(HANDLER, taskOptions.getEventHandler().toString());
     }
 
     //adds all other parameters

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
@@ -117,7 +117,7 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
 
     setExecutionDate(taskOptions, task);
 
-    String queueName = getQueueName(taskOptions.getEvent().getClass(),taskOptions.getEvent().getAssociatedHandlerClass());
+    String queueName = getQueueName(taskOptions.getEvent().getClass(), taskOptions.getEvent().getAssociatedHandlerClass(), taskOptions.getEventListenerClass());
 
     addTaskToTheQueue(taskOptions, queueName, task);
 
@@ -148,12 +148,12 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
       throw new RuntimeException(e);
     }
 
-    if (taskOptions.getEventListener() != null){
-      task.param(LISTENER, taskOptions.getEventListener().toString());
+    if (taskOptions.getEventListenerClass() != null){
+      task.param(LISTENER, taskOptions.getEventListenerClass().getSimpleName());
     }
 
-    if (taskOptions.getEventHandler() != null){
-      task.param(HANDLER, taskOptions.getEventHandler().toString());
+    if (taskOptions.getEventHandlerClass() != null){
+      task.param(HANDLER, taskOptions.getEventHandlerClass().getSimpleName());
     }
 
     //adds all other parameters
@@ -308,9 +308,19 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
     QueueName queueName = null;
 
     for (Class asyncJobClass : asyncJobClasses) {
-      QueueName classQueueName = (QueueName) asyncJobClass.getAnnotation(QueueName.class);
-      if (classQueueName != null && !Strings.isNullOrEmpty(classQueueName.name())) {
-        queueName = classQueueName;
+      if (asyncJobClass != null) {
+        QueueName classQueueName = (QueueName) asyncJobClass.getAnnotation(QueueName.class);
+        if (classQueueName != null && !Strings.isNullOrEmpty(classQueueName.name())) {
+          queueName = classQueueName;
+        } else {
+          // little acrobatics so we can preserve the old behavior
+          classQueueName = (QueueName) asyncJobClasses[0].getAnnotation(QueueName.class);
+          if (classQueueName != null && !Strings.isNullOrEmpty(classQueueName.name())) {
+            queueName = classQueueName;
+          } else {
+            queueName = null;
+          }
+        }
       }
     }
 

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
@@ -55,6 +55,7 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
   public static final String TASK_QUEUE = "taskQueue";
   public static final String EVENT = "event";
   public static final String EVENT_AS_JSON = "eventJson";
+  public static final String LISTENER_ID = "listenerId";
 
   private List<AsyncTaskOptions> taskOptions;
 
@@ -144,6 +145,10 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
       throw new RuntimeException(e);
+    }
+
+    if (taskOptions.getEventListenerId() != null){
+      task.param(LISTENER_ID, taskOptions.getEventListenerId().toString());
     }
 
     //adds all other parameters

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventBusBinder.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventBusBinder.java
@@ -7,20 +7,20 @@ import com.google.inject.multibindings.Multibinder;
  * @author Tsony Tsonev (tsony.tsonev@clouway.com)
  */
 public class AsyncEventBusBinder {
-  private Multibinder<Listener> binder;
+  private Multibinder<ListenerClazz> binder;
 
-  public interface Listener{
-    Class<? extends AsyncEventListener> getListenerClass();
+  public interface ListenerClazz {
+    Class<? extends AsyncEventListener> getValue();
   }
 
   public AsyncEventBusBinder(Binder binder) {
-     this.binder = Multibinder.newSetBinder(binder, Listener.class);
+     this.binder = Multibinder.newSetBinder(binder, ListenerClazz.class);
   }
 
-  public AsyncEventBusBinder addBinding(final Class<? extends AsyncEventListener> listenerClass){
-    binder.addBinding().toInstance(new Listener() {
+  public AsyncEventBusBinder registerListener(final Class<? extends AsyncEventListener> listenerClass){
+    binder.addBinding().toInstance(new ListenerClazz() {
       @Override
-      public Class<? extends AsyncEventListener> getListenerClass() {
+      public Class<? extends AsyncEventListener> getValue() {
         return listenerClass;
       }
     });

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventBusBinder.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventBusBinder.java
@@ -1,0 +1,30 @@
+package com.clouway.asynctaskscheduler.spi;
+
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+
+/**
+ * @author Tsony Tsonev (tsony.tsonev@clouway.com)
+ */
+public class AsyncEventBusBinder {
+  private Multibinder<Listener> binder;
+
+  public interface Listener{
+    Class<? extends AsyncEventListener> getListenerClass();
+  }
+
+  public AsyncEventBusBinder(Binder binder) {
+     this.binder = Multibinder.newSetBinder(binder, Listener.class);
+  }
+
+  public AsyncEventBusBinder addBinding(final Class<? extends AsyncEventListener> listenerClass){
+    binder.addBinding().toInstance(new Listener() {
+      @Override
+      public Class<? extends AsyncEventListener> getListenerClass() {
+        return listenerClass;
+      }
+    });
+    return this;
+  }
+
+}

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListener.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListener.java
@@ -3,8 +3,7 @@ package com.clouway.asynctaskscheduler.spi;
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
-public interface AsyncEventListener {
+public interface AsyncEventListener<E extends AsyncEvent>{
 
-
-  void onEvent(AsyncEvent event);
+  void onEvent(E event);
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface AsyncEventListenersFactory {
   public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass);
   AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName);
+  List<Class<? extends AsyncEventListener>> getListenerClasses(Class<? extends AsyncEvent> eventClass);
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
@@ -7,4 +7,5 @@ import java.util.List;
  */
 public interface AsyncEventListenersFactory {
   public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass);
+  AsyncEventListener createListener(Class<? extends AsyncEventListener> eventListenerClassName);
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
@@ -7,5 +7,5 @@ import java.util.List;
  */
 public interface AsyncEventListenersFactory {
   public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass);
-  AsyncEventListener createListener(Class<? extends AsyncEventListener> eventListenerClassName);
+  AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName);
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncEventListenersFactory.java
@@ -6,7 +6,6 @@ import java.util.List;
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
 public interface AsyncEventListenersFactory {
-  public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass);
   AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName);
   List<Class<? extends AsyncEventListener>> getListenerClasses(Class<? extends AsyncEvent> eventClass);
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
@@ -19,8 +19,8 @@ public class AsyncTaskOptions {
   private AsyncEvent event;
   private String taskName;
   private Boolean transactionless = false;
-  private String eventListener;
-  private String eventHandler;
+  private Class<? extends AsyncEventListener> eventListenerClass;
+  private Class<? extends AsyncEventHandler> eventHandlerClass;
 
 
   private AsyncTaskOptions() {
@@ -75,6 +75,22 @@ public class AsyncTaskOptions {
     return taskOptions;
   }
 
+  public static AsyncTaskOptions eventWithListener(AsyncEvent event, Class<? extends AsyncEventListener> eventListenerClass) {
+    AsyncTaskOptions taskOptions = new AsyncTaskOptions();
+    taskOptions.event = event;
+    taskOptions.params = Maps.newHashMap();
+    taskOptions.eventListenerClass = eventListenerClass;
+    return taskOptions;
+  }
+
+  public static AsyncTaskOptions eventWithHandler(AsyncEvent event, Class<? extends AsyncEventHandler> eventHandlerClass) {
+    AsyncTaskOptions taskOptions = new AsyncTaskOptions();
+    taskOptions.event = event;
+    taskOptions.params = Maps.newHashMap();
+    taskOptions.eventHandlerClass = eventHandlerClass;
+    return taskOptions;
+  }
+
   public AsyncTaskOptions delay(long delayMills) {
     this.delayMills = delayMills;
     executionDateMills = 0;
@@ -94,16 +110,6 @@ public class AsyncTaskOptions {
 
   public AsyncTaskOptions transactionless() {
     transactionless = true;
-    return this;
-  }
-
-  public AsyncTaskOptions eventListener(String eventListener) {
-    this.eventListener = eventListener;
-    return this;
-  }
-
-  public AsyncTaskOptions eventHandler(String eventHandler) {
-    this.eventHandler = eventHandler;
     return this;
   }
 
@@ -146,11 +152,11 @@ public class AsyncTaskOptions {
     return false;
   }
 
-  public String getEventListener() {
-    return eventListener;
+  public Class<? extends AsyncEventListener> getEventListenerClass() {
+    return eventListenerClass;
   }
 
-  public String getEventHandler() {
-    return eventHandler;
+  public Class<? extends AsyncEventHandler> getEventHandlerClass() {
+    return eventHandlerClass;
   }
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
@@ -19,7 +19,8 @@ public class AsyncTaskOptions {
   private AsyncEvent event;
   private String taskName;
   private Boolean transactionless = false;
-  private Integer eventListenerId;
+  private String eventListener;
+  private String eventHandler;
 
 
   private AsyncTaskOptions() {
@@ -96,8 +97,13 @@ public class AsyncTaskOptions {
     return this;
   }
 
-  public AsyncTaskOptions eventListenerId(Integer eventListenerId) {
-    this.eventListenerId = eventListenerId;
+  public AsyncTaskOptions eventListener(String eventListener) {
+    this.eventListener = eventListener;
+    return this;
+  }
+
+  public AsyncTaskOptions eventHandler(String eventHandler) {
+    this.eventHandler = eventHandler;
     return this;
   }
 
@@ -140,7 +146,11 @@ public class AsyncTaskOptions {
     return false;
   }
 
-  public Integer getEventListenerId() {
-    return eventListenerId;
+  public String getEventListener() {
+    return eventListener;
+  }
+
+  public String getEventHandler() {
+    return eventHandler;
   }
 }

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/AsyncTaskOptions.java
@@ -19,6 +19,7 @@ public class AsyncTaskOptions {
   private AsyncEvent event;
   private String taskName;
   private Boolean transactionless = false;
+  private Integer eventListenerId;
 
 
   private AsyncTaskOptions() {
@@ -95,6 +96,11 @@ public class AsyncTaskOptions {
     return this;
   }
 
+  public AsyncTaskOptions eventListenerId(Integer eventListenerId) {
+    this.eventListenerId = eventListenerId;
+    return this;
+  }
+
   public Class<? extends AsyncTask> getAsyncTask() {
     return asyncTask;
   }
@@ -132,5 +138,9 @@ public class AsyncTaskOptions {
       return true;
     }
     return false;
+  }
+
+  public Integer getEventListenerId() {
+    return eventListenerId;
   }
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/TestSuite.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/TestSuite.java
@@ -1,12 +1,6 @@
 package com.clouway.asynctaskscheduler;
 
-import com.clouway.asynctaskscheduler.gae.GsonEventSerializationTest;
-import com.clouway.asynctaskscheduler.gae.RoutingEventDispatcherTest;
-import com.clouway.asynctaskscheduler.gae.RoutingTaskDispatcherTest;
-import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskExecutorServletTest;
-import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskSchedulerErrorHandlingTest;
-import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskSchedulerTest;
-import com.clouway.asynctaskscheduler.gae.TaskQueueEventBusTest;
+import com.clouway.asynctaskscheduler.gae.*;
 import com.clouway.asynctaskscheduler.spi.AsyncTaskParamsTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -23,7 +17,8 @@ import org.junit.runners.Suite;
         TaskQueueAsyncTaskExecutorServletTest.class,
         TaskQueueAsyncTaskSchedulerErrorHandlingTest.class,
         TaskQueueAsyncTaskSchedulerTest.class,
-        TaskQueueEventBusTest.class
+        TaskQueueEventBusTest.class,
+        AsyncEventListenersFactoryProviderTest.class
 })
 public class TestSuite {
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/TestSuite.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/TestSuite.java
@@ -1,0 +1,29 @@
+package com.clouway.asynctaskscheduler;
+
+import com.clouway.asynctaskscheduler.gae.GsonEventSerializationTest;
+import com.clouway.asynctaskscheduler.gae.RoutingEventDispatcherTest;
+import com.clouway.asynctaskscheduler.gae.RoutingTaskDispatcherTest;
+import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskExecutorServletTest;
+import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskSchedulerErrorHandlingTest;
+import com.clouway.asynctaskscheduler.gae.TaskQueueAsyncTaskSchedulerTest;
+import com.clouway.asynctaskscheduler.gae.TaskQueueEventBusTest;
+import com.clouway.asynctaskscheduler.spi.AsyncTaskParamsTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * @author Tsony Tsonev (tsony.tsonev@clouway.com)
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AsyncTaskParamsTest.class,
+        GsonEventSerializationTest.class,
+        RoutingEventDispatcherTest.class,
+        RoutingTaskDispatcherTest.class,
+        TaskQueueAsyncTaskExecutorServletTest.class,
+        TaskQueueAsyncTaskSchedulerErrorHandlingTest.class,
+        TaskQueueAsyncTaskSchedulerTest.class,
+        TaskQueueEventBusTest.class
+})
+public class TestSuite {
+}

--- a/src/test/java/com/clouway/asynctaskscheduler/common/DefaultActionEventListener.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/common/DefaultActionEventListener.java
@@ -1,0 +1,18 @@
+package com.clouway.asynctaskscheduler.common;
+
+import com.clouway.asynctaskscheduler.gae.QueueName;
+import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
+
+/**
+ * @author Tsony Tsonev (tsony.tsonev@clouway.com)
+ */
+@QueueName(name = "customListenerTaskQueue")
+public class DefaultActionEventListener implements AsyncEventListener<ActionEvent>{
+  public static final String CUSTOM_LISTENER_TASK_QUEUE_NAME = "customListenerTaskQueue";
+  public ActionEvent actionEvent;
+
+  @Override
+  public void onEvent(ActionEvent event) {
+    this.actionEvent = event;
+  }
+}

--- a/src/test/java/com/clouway/asynctaskscheduler/common/IndexingListener.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/common/IndexingListener.java
@@ -6,11 +6,11 @@ import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
-public class IndexingListener implements AsyncEventListener{
+public class IndexingListener implements AsyncEventListener<ActionEvent>{
   public AsyncEvent event;
 
   @Override
-  public void onEvent(AsyncEvent event) {
+  public void onEvent(ActionEvent event) {
     this.event = event;
   }
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/common/MultyInterfaceListener.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/common/MultyInterfaceListener.java
@@ -1,0 +1,83 @@
+package com.clouway.asynctaskscheduler.common;
+
+import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author Tsony Tsonev (tsony.tsonev@clouway.com)
+ */
+public class MultyInterfaceListener implements AsyncEventListener<ActionEvent>, Serializable, Set<Integer>{
+  @Override
+  public void onEvent(ActionEvent event) {
+
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return false;
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return false;
+  }
+
+  @Override
+  public Iterator<Integer> iterator() {
+    return null;
+  }
+
+  @Override
+  public Object[] toArray() {
+    return new Object[0];
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return null;
+  }
+
+  @Override
+  public boolean add(Integer integer) {
+    return false;
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return false;
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends Integer> c) {
+    return false;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return false;
+  }
+
+  @Override
+  public void clear() {
+
+  }
+}

--- a/src/test/java/com/clouway/asynctaskscheduler/common/TestEventListener.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/common/TestEventListener.java
@@ -6,11 +6,11 @@ import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
-public class TestEventListener implements AsyncEventListener {
+public class TestEventListener implements AsyncEventListener<ActionEvent> {
   public AsyncEvent event;
 
   @Override
-  public void onEvent(AsyncEvent event) {
+  public void onEvent(ActionEvent event) {
     this.event = event;
   }
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
@@ -1,23 +1,16 @@
 package com.clouway.asynctaskscheduler.gae;
 
 import com.clouway.asynctaskscheduler.common.ActionEvent;
-import com.clouway.asynctaskscheduler.common.DefaultActionEvent;
 import com.clouway.asynctaskscheduler.common.IndexingListener;
 import com.clouway.asynctaskscheduler.common.TestEventListener;
-import com.clouway.asynctaskscheduler.spi.AsyncEvent;
-import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
+import com.clouway.asynctaskscheduler.spi.AsyncEventBusBinder;
 import com.clouway.asynctaskscheduler.spi.AsyncEventListenersFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
-import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.MapBinder;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -35,22 +28,16 @@ public class AsyncEventListenersFactoryProviderTest {
     Injector injector = Guice.createInjector(new BackgroundTasksModule(), new AbstractModule() {
       @Override
       protected void configure() {
-        TypeLiteral<Class<? extends AsyncEvent>> eventType = new TypeLiteral<Class<? extends AsyncEvent>>(){};
-        TypeLiteral<List<Class<? extends AsyncEventListener>>> eventListenersType = new TypeLiteral<List<Class<? extends AsyncEventListener>>>(){};
+        new AsyncEventBusBinder(binder())
+                .addBinding(IndexingListener.class);
 
-        MapBinder<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>> mapBinder = MapBinder.newMapBinder(binder(), eventType, eventListenersType);
-
-        List<Class<? extends AsyncEventListener>> listeners = new ArrayList<Class<? extends AsyncEventListener>>();
-        listeners.add(IndexingListener.class);
-        listeners.add(TestEventListener.class);
-
-        mapBinder.addBinding(ActionEvent.class).toInstance(listeners);
-
-        listeners = new ArrayList<Class<? extends AsyncEventListener>>();
-        listeners.add(IndexingListener.class);
-        mapBinder.addBinding(DefaultActionEvent.class).toInstance(listeners);
       }
-
+    }, new AbstractModule() {
+      @Override
+      protected void configure() {
+        new AsyncEventBusBinder(binder())
+                .addBinding(TestEventListener.class);
+      }
     });
 
     Provider<AsyncEventListenersFactory> provider = injector.getProvider(AsyncEventListenersFactory.class);
@@ -60,8 +47,7 @@ public class AsyncEventListenersFactoryProviderTest {
 
   @Test
   public void createListOfListeners() throws Exception {
-    assertThat(listenersFactory.create(ActionEvent.class).size(), is(2));
-    assertThat(listenersFactory.create(DefaultActionEvent.class).size(), is(1));
+    assertThat(listenersFactory.getListenerClasses(ActionEvent.class).size(), is(2));
   }
 
   @Test
@@ -71,5 +57,23 @@ public class AsyncEventListenersFactoryProviderTest {
 
     TestEventListener testEventListener = (TestEventListener) listenersFactory.createListener(ActionEvent.class, TestEventListener.class.getSimpleName());
     assertThat(testEventListener, notNullValue());
+  }
+
+  @Test
+  public void pretendToNotExecuteSameListenerEvenIfAddedMoreThanOce() throws Exception {
+    Injector injector = Guice.createInjector(new BackgroundTasksModule(), new AbstractModule() {
+      @Override
+      protected void configure() {
+        new AsyncEventBusBinder(binder())
+                .addBinding(IndexingListener.class)
+                .addBinding(TestEventListener.class)
+                .addBinding(TestEventListener.class)
+                .addBinding(TestEventListener.class);
+      }
+    });
+
+    listenersFactory = injector.getProvider(AsyncEventListenersFactory.class).get();
+
+    assertThat(listenersFactory.getListenerClasses(ActionEvent.class).size(), is(2));
   }
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
@@ -2,6 +2,7 @@ package com.clouway.asynctaskscheduler.gae;
 
 import com.clouway.asynctaskscheduler.common.ActionEvent;
 import com.clouway.asynctaskscheduler.common.IndexingListener;
+import com.clouway.asynctaskscheduler.common.MultyInterfaceListener;
 import com.clouway.asynctaskscheduler.common.TestEventListener;
 import com.clouway.asynctaskscheduler.spi.AsyncEventBusBinder;
 import com.clouway.asynctaskscheduler.spi.AsyncEventListenersFactory;
@@ -29,14 +30,14 @@ public class AsyncEventListenersFactoryProviderTest {
       @Override
       protected void configure() {
         new AsyncEventBusBinder(binder())
-                .addBinding(IndexingListener.class);
+                .registerListener(IndexingListener.class);
 
       }
     }, new AbstractModule() {
       @Override
       protected void configure() {
         new AsyncEventBusBinder(binder())
-                .addBinding(TestEventListener.class);
+                .registerListener(TestEventListener.class);
       }
     });
 
@@ -65,15 +66,32 @@ public class AsyncEventListenersFactoryProviderTest {
       @Override
       protected void configure() {
         new AsyncEventBusBinder(binder())
-                .addBinding(IndexingListener.class)
-                .addBinding(TestEventListener.class)
-                .addBinding(TestEventListener.class)
-                .addBinding(TestEventListener.class);
+                .registerListener(IndexingListener.class)
+                .registerListener(TestEventListener.class)
+                .registerListener(TestEventListener.class)
+                .registerListener(TestEventListener.class);
       }
     });
 
     listenersFactory = injector.getProvider(AsyncEventListenersFactory.class).get();
 
     assertThat(listenersFactory.getListenerClasses(ActionEvent.class).size(), is(2));
+  }
+
+  @Test
+  public void pretendCorrectnessIfListenerImplementsMoreThanOneInterface() throws Exception {
+    Injector injector = Guice.createInjector(new BackgroundTasksModule(), new AbstractModule() {
+      @Override
+      protected void configure() {
+        new AsyncEventBusBinder(binder())
+                .registerListener(IndexingListener.class)
+                .registerListener(TestEventListener.class)
+                .registerListener(MultyInterfaceListener.class);
+      }
+    });
+
+    listenersFactory = injector.getProvider(AsyncEventListenersFactory.class).get();
+
+    assertThat(listenersFactory.getListenerClasses(ActionEvent.class).size(), is(3));
   }
 }

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/AsyncEventListenersFactoryProviderTest.java
@@ -1,0 +1,75 @@
+package com.clouway.asynctaskscheduler.gae;
+
+import com.clouway.asynctaskscheduler.common.ActionEvent;
+import com.clouway.asynctaskscheduler.common.DefaultActionEvent;
+import com.clouway.asynctaskscheduler.common.IndexingListener;
+import com.clouway.asynctaskscheduler.common.TestEventListener;
+import com.clouway.asynctaskscheduler.spi.AsyncEvent;
+import com.clouway.asynctaskscheduler.spi.AsyncEventListener;
+import com.clouway.asynctaskscheduler.spi.AsyncEventListenersFactory;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Tsony Tsonev (tsony.tsonev@clouway.com)
+ */
+public class AsyncEventListenersFactoryProviderTest {
+
+  private AsyncEventListenersFactory listenersFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    Injector injector = Guice.createInjector(new BackgroundTasksModule(), new AbstractModule() {
+      @Override
+      protected void configure() {
+        TypeLiteral<Class<? extends AsyncEvent>> eventType = new TypeLiteral<Class<? extends AsyncEvent>>(){};
+        TypeLiteral<List<Class<? extends AsyncEventListener>>> eventListenersType = new TypeLiteral<List<Class<? extends AsyncEventListener>>>(){};
+
+        MapBinder<Class<? extends AsyncEvent>, List<Class<? extends AsyncEventListener>>> mapBinder = MapBinder.newMapBinder(binder(), eventType, eventListenersType);
+
+        List<Class<? extends AsyncEventListener>> listeners = new ArrayList<Class<? extends AsyncEventListener>>();
+        listeners.add(IndexingListener.class);
+        listeners.add(TestEventListener.class);
+
+        mapBinder.addBinding(ActionEvent.class).toInstance(listeners);
+
+        listeners = new ArrayList<Class<? extends AsyncEventListener>>();
+        listeners.add(IndexingListener.class);
+        mapBinder.addBinding(DefaultActionEvent.class).toInstance(listeners);
+      }
+
+    });
+
+    Provider<AsyncEventListenersFactory> provider = injector.getProvider(AsyncEventListenersFactory.class);
+
+    listenersFactory = provider.get();
+  }
+
+  @Test
+  public void createListOfListeners() throws Exception {
+    assertThat(listenersFactory.create(ActionEvent.class).size(), is(2));
+    assertThat(listenersFactory.create(DefaultActionEvent.class).size(), is(1));
+  }
+
+  @Test
+  public void createListenerByName() throws Exception {
+    IndexingListener indexingListener = (IndexingListener) listenersFactory.createListener(ActionEvent.class, IndexingListener.class.getSimpleName());
+    assertThat(indexingListener, notNullValue());
+
+    TestEventListener testEventListener = (TestEventListener) listenersFactory.createListener(ActionEvent.class, TestEventListener.class.getSimpleName());
+    assertThat(testEventListener, notNullValue());
+  }
+}

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcherTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcherTest.java
@@ -67,6 +67,14 @@ public class RoutingEventDispatcherTest {
     public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
       return testEventListener;
     }
+
+    @Override
+    public List<Class<? extends AsyncEventListener>> getListenerClasses(Class<? extends AsyncEvent> eventClass) {
+      List<Class<? extends AsyncEventListener>> listeners = new ArrayList<Class<? extends AsyncEventListener>>();
+      listeners.add(IndexingListener.class);
+      listeners.add(TestEventListener.class);
+      return listeners;
+    }
   };
 
   private String eventClassAsString = ActionEvent.class.getName();
@@ -125,6 +133,11 @@ public class RoutingEventDispatcherTest {
       @Override
       public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
         return null;
+      }
+
+      @Override
+      public List<Class<? extends AsyncEventListener>> getListenerClasses(Class<? extends AsyncEvent> eventClass) {
+        return Lists.newArrayList();
       }
     };
 

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcherTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/RoutingEventDispatcherTest.java
@@ -56,14 +56,6 @@ public class RoutingEventDispatcherTest {
   TestEventListener testEventListener = new TestEventListener();
   private AsyncEventListenersFactory listenersFactory = new AsyncEventListenersFactory() {
     @Override
-    public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
-      List<AsyncEventListener> listeners = new ArrayList<AsyncEventListener>();
-      listeners.add(indexingListener);
-      listeners.add(testEventListener);
-      return listeners;
-    }
-
-    @Override
     public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
       return testEventListener;
     }
@@ -124,12 +116,6 @@ public class RoutingEventDispatcherTest {
   @Test
   public void dispatchAsyncEventInSameTaskQueueIfNoListeners() throws Exception {
     listenersFactory = new AsyncEventListenersFactory() {
-      @Override
-      public List<AsyncEventListener> create(Class<? extends AsyncEvent> eventClass) {
-        //no listeners for the event, as the test description says
-        return Lists.newArrayList();
-      }
-
       @Override
       public AsyncEventListener createListener(Class<? extends AsyncEvent> eventClass, String eventListenerClassName) {
         return null;

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
@@ -52,15 +52,15 @@ public class TaskQueueAsyncTaskExecutorServletTest {
   public void dispatchingEventListener() throws Exception {
     String eventValue = "event as json";
     String encodedEventValue = URLEncoder.encode("event as json","UTF-8");
-    String eventListenerId = "1";
+    String eventListener = "com.clouway.DummyClass";
 
     when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT)).thenReturn("event.class");
     when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT_AS_JSON)).thenReturn(encodedEventValue);
-    when(request.getParameter(TaskQueueAsyncTaskScheduler.LISTENER_ID)).thenReturn(eventListenerId);
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.LISTENER)).thenReturn(eventListener);
 
     servlet.doGet(request, response);
 
-    verify(eventDisplatcher).dispatchEventListener("event.class", eventValue, new Integer(eventListenerId));
+    verify(eventDisplatcher).dispatchEventListener("event.class", eventValue, eventListener);
     verifyZeroInteractions(routingTaskDispatcher);
 
   }

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
@@ -66,6 +66,23 @@ public class TaskQueueAsyncTaskExecutorServletTest {
   }
 
   @Test
+  public void dispatchingEventHandler() throws Exception {
+    String eventValue = "event as json";
+    String encodedEventValue = URLEncoder.encode("event as json","UTF-8");
+    String eventHandler = "com.clouway.DummyClass";
+
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT)).thenReturn("event.class");
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT_AS_JSON)).thenReturn(encodedEventValue);
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.HANDLER)).thenReturn(eventHandler);
+
+    servlet.doGet(request, response);
+
+    verify(eventDisplatcher).dispatchEventHandler("event.class", eventValue, eventHandler);
+    verifyZeroInteractions(routingTaskDispatcher);
+
+  }
+
+  @Test
   public void dispatchingAsyncTask() throws Exception {
 
     when(request.getParameter(TaskQueueAsyncTaskScheduler.TASK_QUEUE)).thenReturn("task.class");

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskExecutorServletTest.java
@@ -49,6 +49,23 @@ public class TaskQueueAsyncTaskExecutorServletTest {
   }
 
   @Test
+  public void dispatchingEventListener() throws Exception {
+    String eventValue = "event as json";
+    String encodedEventValue = URLEncoder.encode("event as json","UTF-8");
+    String eventListenerId = "1";
+
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT)).thenReturn("event.class");
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.EVENT_AS_JSON)).thenReturn(encodedEventValue);
+    when(request.getParameter(TaskQueueAsyncTaskScheduler.LISTENER_ID)).thenReturn(eventListenerId);
+
+    servlet.doGet(request, response);
+
+    verify(eventDisplatcher).dispatchEventListener("event.class", eventValue, new Integer(eventListenerId));
+    verifyZeroInteractions(routingTaskDispatcher);
+
+  }
+
+  @Test
   public void dispatchingAsyncTask() throws Exception {
 
     when(request.getParameter(TaskQueueAsyncTaskScheduler.TASK_QUEUE)).thenReturn("task.class");

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
@@ -1,10 +1,6 @@
 package com.clouway.asynctaskscheduler.gae;
 
-import com.clouway.asynctaskscheduler.common.ActionEvent;
-import com.clouway.asynctaskscheduler.common.CustomTaskQueueAsyncTask;
-import com.clouway.asynctaskscheduler.common.DefaultActionEvent;
-import com.clouway.asynctaskscheduler.common.DefaultTaskQueueAsyncTask;
-import com.clouway.asynctaskscheduler.common.TaskQueueParamParser;
+import com.clouway.asynctaskscheduler.common.*;
 import com.clouway.asynctaskscheduler.spi.AsyncTask;
 import com.clouway.asynctaskscheduler.spi.AsyncTaskOptions;
 import com.clouway.asynctaskscheduler.util.FakeCommonParamBinder;
@@ -227,27 +223,25 @@ public class TaskQueueAsyncTaskSchedulerTest {
   @Test
   public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventListenerIsProvided() throws Exception {
     ActionEvent event = new ActionEvent("test message");
-    String eventListener = "com.clouway.DummyClass";
-    taskScheduler.add(AsyncTaskOptions.event(event).eventListener(eventListener))
+    taskScheduler.add(AsyncTaskOptions.eventWithListener(event, TestEventListener.class))
             .now();
 
     QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
-    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.LISTENER, eventListener);
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.LISTENER, TestEventListener.class.getSimpleName());
   }
 
   @Test
   public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventHandlerIsProvided() throws Exception {
     ActionEvent event = new ActionEvent("test message");
-    String eventHandler = "com.clouway.DummyClass";
-    taskScheduler.add(AsyncTaskOptions.event(event).eventHandler(eventHandler))
+    taskScheduler.add(AsyncTaskOptions.eventWithHandler(event, ActionEventHandler.class))
             .now();
 
     QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
-    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.HANDLER, eventHandler);
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.HANDLER, ActionEventHandler.class.getSimpleName());
   }
 
   @Test
@@ -272,6 +266,22 @@ public class TaskQueueAsyncTaskSchedulerTest {
             .now();
 
     QueueStateInfo qsi = getQueueStateInfo(DefaultActionEvent.CUSTOM_TASK_QUEUE_NAME);
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
+  }
+
+  @Test
+  public void shouldAddTaskToCustomTaskQueueWhenTaskOptionsForEventWithListenerIsProvided() throws Exception {
+    DefaultActionEvent event = new DefaultActionEvent("test message");
+    taskScheduler.add(AsyncTaskOptions.eventWithListener(event, DefaultActionEventListener.class))
+            .add(AsyncTaskOptions.eventWithHandler(event, DefaultActionEventHandler.class))
+            .now();
+
+    QueueStateInfo qsi = getQueueStateInfo(DefaultActionEventListener.CUSTOM_LISTENER_TASK_QUEUE_NAME);
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
+
+    qsi = getQueueStateInfo(DefaultActionEvent.CUSTOM_TASK_QUEUE_NAME);
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
   }

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
@@ -225,16 +225,29 @@ public class TaskQueueAsyncTaskSchedulerTest {
   }
 
   @Test
-  public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventListenerIsProvided() throws Exception {//////////////////////////test
+  public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventListenerIsProvided() throws Exception {
     ActionEvent event = new ActionEvent("test message");
-    Integer eventListenerId = 1;
-    taskScheduler.add(AsyncTaskOptions.event(event).eventListenerId(eventListenerId))
+    String eventListener = "com.clouway.DummyClass";
+    taskScheduler.add(AsyncTaskOptions.event(event).eventListener(eventListener))
             .now();
 
     QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
     assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
-    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.LISTENER_ID, eventListenerId.toString());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.LISTENER, eventListener);
+  }
+
+  @Test
+  public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventHandlerIsProvided() throws Exception {
+    ActionEvent event = new ActionEvent("test message");
+    String eventHandler = "com.clouway.DummyClass";
+    taskScheduler.add(AsyncTaskOptions.event(event).eventHandler(eventHandler))
+            .now();
+
+    QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.HANDLER, eventHandler);
   }
 
   @Test

--- a/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
+++ b/src/test/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskSchedulerTest.java
@@ -39,7 +39,6 @@ import static com.clouway.asynctaskscheduler.spi.AsyncTaskOptions.task;
 import static com.clouway.asynctaskscheduler.util.DateUtil.newDateAndTime;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.fail;
 
 /**
  * @author Mihail Lesikov (mlesikov@gmail.com)
@@ -223,6 +222,19 @@ public class TaskQueueAsyncTaskSchedulerTest {
     QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
 
     assertParams(qsi.getTaskInfo().get(0).getBody(), paramName, paramValue);
+  }
+
+  @Test
+  public void shouldAddTaskToDefaultTaskQueueWhenTaskOptionsForEventListenerIsProvided() throws Exception {//////////////////////////test
+    ActionEvent event = new ActionEvent("test message");
+    Integer eventListenerId = 1;
+    taskScheduler.add(AsyncTaskOptions.event(event).eventListenerId(eventListenerId))
+            .now();
+
+    QueueStateInfo qsi = getQueueStateInfo(QueueFactory.getDefaultQueue().getQueueName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT, event.getClass().getName());
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.EVENT_AS_JSON, encode(gson.toJson(event)));
+    assertParams(qsi.getTaskInfo().get(0).getBody(), TaskQueueAsyncTaskScheduler.LISTENER_ID, eventListenerId.toString());
   }
 
   @Test

--- a/src/test/java/queue.xml
+++ b/src/test/java/queue.xml
@@ -11,6 +11,11 @@
   </queue>
 
   <queue>
+    <name>customListenerTaskQueue</name>
+    <rate>1/s</rate>
+  </queue>
+
+  <queue>
     <name>customActionEventTaskQueue</name>
     <rate>1/s</rate>
   </queue>


### PR DESCRIPTION
Issue: #7

  Listener can be registered in modules as it follows:
 
 Bindings can be added in different modules for different events or
 for already added events. Single event can have more than one listeners
 Same listener can be bound only once to event, even if tried to be added
 multiple times exception wont be thrown.

Example for mapping in extender of abstract module:
```java
        new AsyncEventBusBinder(binder())
       .registerListener(ContractSignedEventListener.class)
       .registerListener(ContractChangedEventListener.class);
```

Also now gaevents will fire a new taskqueue for each listener and for the handler in datastore transaction.