### PR TITLE
Add configuration for provisioning of custom headers to new tasks

### DIFF
--- a/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/BackgroundTasksModule.java
@@ -38,10 +38,15 @@ public class BackgroundTasksModule extends AbstractModule {
   protected void configure() {
     install(servletsModule);
     bind(EventTransport.class).to(getEventTransport()).in(Singleton.class);
+    bind(HeadersProvider.class).to(getHeadersProvider()).in(Singleton.class);
   }
 
   protected Class<? extends EventTransport> getEventTransport() {
     return GsonEventTransport.class;
+  }
+
+  protected Class<? extends HeadersProvider> getHeadersProvider() {
+    return DefaultHeadersProvider.class;
   }
 
   @Provides
@@ -50,8 +55,8 @@ public class BackgroundTasksModule extends AbstractModule {
   }
 
   @Provides
-  public AsyncTaskScheduler getAsyncTaskScheduler(EventTransport eventTransport, Provider<CommonParamBinder> commonParamBinderProvider, TaskApplier taskApplier) {
-    return new TaskQueueAsyncTaskScheduler(eventTransport, commonParamBinderProvider.get(), taskApplier);
+  public AsyncTaskScheduler getAsyncTaskScheduler(EventTransport eventTransport, Provider<CommonParamBinder> commonParamBinderProvider, TaskApplier taskApplier, HeadersProvider headersProvider) {
+    return new TaskQueueAsyncTaskScheduler(eventTransport, commonParamBinderProvider.get(), taskApplier, headersProvider);
   }
 
   @Override

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/DefaultHeadersProvider.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/DefaultHeadersProvider.java
@@ -1,0 +1,16 @@
+package com.clouway.asynctaskscheduler.gae;
+
+import com.clouway.asynctaskscheduler.spi.HeadersProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Georgi Georgiev (georgi.georgiev@clouway.com)
+ */
+public class DefaultHeadersProvider implements HeadersProvider {
+  @Override
+  public Map<String, String> get() {
+    return new HashMap<String, String>();
+  }
+}

--- a/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/gae/TaskQueueAsyncTaskScheduler.java
@@ -4,6 +4,7 @@ import com.clouway.asynctaskscheduler.spi.AsyncEvent;
 import com.clouway.asynctaskscheduler.spi.AsyncTaskOptions;
 import com.clouway.asynctaskscheduler.spi.AsyncTaskScheduler;
 import com.clouway.asynctaskscheduler.spi.EventTransport;
+import com.clouway.asynctaskscheduler.spi.HeadersProvider;
 import com.google.appengine.api.taskqueue.TaskAlreadyExistsException;
 import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.api.taskqueue.TransientFailureException;
@@ -62,14 +63,19 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
 
   private final EventTransport eventTransport;
   private final CommonParamBinder commonParamBinder;
-  private TaskApplier taskApplier;
+  private final TaskApplier taskApplier;
+  private final HeadersProvider headersProvider;
 
 
   @Inject
-  public TaskQueueAsyncTaskScheduler(EventTransport eventTransport, CommonParamBinder commonParamBinder, TaskApplier taskApplier) {
+  public TaskQueueAsyncTaskScheduler(EventTransport eventTransport,
+                                     CommonParamBinder commonParamBinder,
+                                     TaskApplier taskApplier,
+                                     HeadersProvider headersProvider) {
     this.eventTransport = eventTransport;
     this.commonParamBinder = commonParamBinder;
     this.taskApplier = taskApplier;
+    this.headersProvider = headersProvider;
     this.taskOptions = Lists.newArrayList();
   }
 
@@ -202,6 +208,8 @@ public class TaskQueueAsyncTaskScheduler implements AsyncTaskScheduler {
 
   private void addTaskToTheQueue(AsyncTaskOptions taskOptions, String queue, TaskOptions task) {
     try {
+
+      task.headers(headersProvider.get());
 
       taskApplier.apply(task, queue, taskOptions.isTransactionless());
 

--- a/src/main/java/com/clouway/asynctaskscheduler/spi/HeadersProvider.java
+++ b/src/main/java/com/clouway/asynctaskscheduler/spi/HeadersProvider.java
@@ -1,0 +1,12 @@
+package com.clouway.asynctaskscheduler.spi;
+
+import java.util.Map;
+
+/**
+ * @author Georgi Georgiev (georgi.georgiev@clouway.com)
+ */
+public interface HeadersProvider {
+
+  Map<String, String> get();
+
+}


### PR DESCRIPTION
Added interface `HeadersProvider` which allow to external applications to attach headers to every task. 